### PR TITLE
Add emulator

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 -->
     <head>
         <link href="css/roundslider.min.css" rel="stylesheet" />
-		<link href="css/throttle.css"  rel="stylesheet">
+        <link href="css/throttle.css"  rel="stylesheet">
         <script  type="text/javascript" src="js/jquery-3.2.1.min.js"></script>  
         <script  type="text/javascript" src="js/jquery-ui.min.js"></script>                                 
         <script  type="text/javascript" src="js/roundslider.min.js"></script>
@@ -29,6 +29,7 @@
         <script  type="text/javascript" src="js/commandController.js"></script>
         <script  type="text/javascript" src="js/storageController.js"></script> 
         <script  type="text/javascript" src="js/exwebthrottle.js"></script> 
+        
 <!--
     NOTE: You can replace the above links with these if you like if you will always run when
           connected to the internet. Using the links above, they must be installed on your machine.
@@ -62,7 +63,13 @@
                             </button>
                         </div>
                         <div class="formbuilder-button form-group field-button-submit column-1"></div>
-                        <div class="server-button form-group field-button-submit column-4">
+                        
+                        <!--<div class="server-button form-group field-button-submit column-4"> -->
+                        <div class="server-button column-4">
+                            <select id="select-method" class="select-map" name="selectMethod" title="Change the connection method">
+                                <option value="serial">Serial</option>
+                                <option value="emulator">Emulator</option>
+                            </select>
                             <button type="button" class="btn-default btn" aria-state="connected" name="button-connect" access="false" id="button-connect">
                                 Connect DCC++ EX
                             </button>

--- a/js/commandController.js
+++ b/js/commandController.js
@@ -3,10 +3,13 @@ $(document).ready(function(){
 });
 
 async function connectServer() {
+    // Gets values of the connection method selector
     selectMethod = document.getElementById('select-method')
     mode = selectMethod.value;
+    // Disables selector so it can't be changed whilst connected
     selectMethod.disabled = true;
     console.log("Set mode: "+mode)
+    // Checks which method was selected
     if (mode == "serial") {
         try{
             // - Request a port and open an asynchronous connection, 
@@ -44,7 +47,9 @@ async function connectServer() {
             return false;
         }
     } else{
+        // If using the emulator
         emulator = true;
+        // Displays dummy hardware message
         displayLog("DCC++ BASE STATION FOR EMULATOR / EMULATOR MOTOR SHIELD: V-1.0.0 / Feb 30 2020 13:10:04")
         return true;
     }
@@ -66,6 +71,7 @@ async function readLoop() {
     }
 }
 function writeToStream(...lines) {
+    // Stops data being written to nonexistent port if using emulator
     if (port) {
         const writer = outputStream.getWriter();
         lines.forEach((line) => {
@@ -145,8 +151,10 @@ async function disconnectServer() {
         port = null;
         displayLog('close port');
     } else {
+        // Disables emulator
         emulator = undefined;
     }
+    // Allows a new method to be chosen
     selectMethod.disabled = false;
 }
 
@@ -162,6 +170,7 @@ async function toggleServer(btn) {
 
     // Otherwise, call the connect() routine when the user clicks the connect button
     success = await connectServer();
+    // Checks if the port was opened successfully
     if (success) {
         btn.attr('aria-state','Connected');
         btn.html("Disconnect DCC++ EX");

--- a/js/commandController.js
+++ b/js/commandController.js
@@ -8,38 +8,45 @@ async function connectServer() {
     selectMethod.disabled = true;
     console.log("Set mode: "+mode)
     if (mode == "serial") {
-        // - Request a port and open an asynchronous connection, 
-        //   which prevents the UI from blocking when waiting for
-        //   input, and allows serial to be received by the web page
-        //   whenever it arrives.
-        
-        port = await navigator.serial.requestPort(); // prompt user to select device connected to a com port
-        // - Wait for the port to open.
-        await port.open({ baudrate: 115200 });         // open the port at the proper supported baud rate
+        try{
+            // - Request a port and open an asynchronous connection, 
+            //   which prevents the UI from blocking when waiting for
+            //   input, and allows serial to be received by the web page
+            //   whenever it arrives.
+            
+            port = await navigator.serial.requestPort(); // prompt user to select device connected to a com port
+            // - Wait for the port to open.
+            await port.open({ baudrate: 115200 });         // open the port at the proper supported baud rate
 
-        // create a text encoder stream and pipe the stream to port.writeable
-        const encoder = new TextEncoderStream();
-        outputDone = encoder.readable.pipeTo(port.writable);
-        outputStream = encoder.writable;
+            // create a text encoder stream and pipe the stream to port.writeable
+            const encoder = new TextEncoderStream();
+            outputDone = encoder.readable.pipeTo(port.writable);
+            outputStream = encoder.writable;
 
-        // To put the system into a known state and stop it from echoing back the characters that we send it, 
-        // we need to send a CTRL-C and turn off the echo
-        writeToStream('\x03', 'echo(false);');
+            // To put the system into a known state and stop it from echoing back the characters that we send it, 
+            // we need to send a CTRL-C and turn off the echo
+            writeToStream('\x03', 'echo(false);');
 
-        // Create an input stream and a reader to read the data. port.readable gets the readable stream
-        // DCC++ commands are text, so we will pipe it through a text decoder. 
-        let decoder = new TextDecoderStream();
-        inputDone = port.readable.pipeTo(decoder.writable);
-        inputStream = decoder.readable
-        //  .pipeThrough(new TransformStream(new LineBreakTransformer())); // added this line to pump through transformer
-        .pipeThrough(new TransformStream(new JSONTransformer()));
+            // Create an input stream and a reader to read the data. port.readable gets the readable stream
+            // DCC++ commands are text, so we will pipe it through a text decoder. 
+            let decoder = new TextDecoderStream();
+            inputDone = port.readable.pipeTo(decoder.writable);
+            inputStream = decoder.readable
+            //  .pipeThrough(new TransformStream(new LineBreakTransformer())); // added this line to pump through transformer
+            .pipeThrough(new TransformStream(new JSONTransformer()));
 
-        // get a reader and start the non-blocking asynchronous read loop to read data from the stream.
-        reader = inputStream.getReader();
-        readLoop();
+            // get a reader and start the non-blocking asynchronous read loop to read data from the stream.
+            reader = inputStream.getReader();
+            readLoop();
+            return true;
+        } catch (err) {
+            console.log("User didn't select a port to connect to")
+            return false;
+        }
     } else{
         emulator = true;
         displayLog("DCC++ BASE STATION FOR EMULATOR / EMULATOR MOTOR SHIELD: V-1.0.0 / Feb 30 2020 13:10:04")
+        return true;
     }
 }
 async function readLoop() {
@@ -154,9 +161,13 @@ async function toggleServer(btn) {
     }
 
     // Otherwise, call the connect() routine when the user clicks the connect button
-    await connectServer();
-    btn.attr('aria-state','Connected');
-    btn.html("Disconnect DCC++ EX");
+    success = await connectServer();
+    if (success) {
+        btn.attr('aria-state','Connected');
+        btn.html("Disconnect DCC++ EX");
+    } else {
+        selectMethod.disabled = false;
+    }
 }
 
 // Display log of events

--- a/js/exwebthrottle.js
+++ b/js/exwebthrottle.js
@@ -57,6 +57,7 @@ window.functions = {
 };
 
 let port;
+let emulator;
 let reader;
 let inputDone;
 let outputDone;


### PR DESCRIPTION
I have added an emulator to the web interface. There is now a dropdown menu next to the connect button that lets the user select between serial and the emulator (serial is the default).
![image](https://user-images.githubusercontent.com/70395217/93720132-f4d0d800-fb7e-11ea-82ac-233774dba129.png)
 If the emulator is selected, it allows the whole of the emulator interface to be used without errors, whilst still providing the debug statements in the debug console.
I also added handling of the error that occurs if the user cancels the serial port selection. 
This is the feature I was talking about in issue #7 (Add an Emulator). 