### PR TITLE
Add guard to warn user if no serial ports are found

### DIFF
--- a/js/commandController.js
+++ b/js/commandController.js
@@ -214,7 +214,7 @@ async function toggleServer(btn) {
         btn.html('<span class="con-ind connected"></span>Disconnect DCC++ EX');
     } else {
         selectMethod.disabled = false;
-		if (!"serial" in navigator) {
+		if (!("serial" in navigator)) {
 			alert("No serial port found!\nYour browser may not be supported - check in the EX-WebThrottle documentation");
 		} else {
 			alert("Unable to connect");

--- a/js/commandController.js
+++ b/js/commandController.js
@@ -217,7 +217,7 @@ async function toggleServer(btn) {
 		if (!("serial" in navigator)) {
 			alert("No serial port found!\nYour browser may not be supported - check in the EX-WebThrottle documentation");
 		} else {
-			alert("Unable to connect");
+			alert("Unable to connect - you may need to allow access with a pop-up");
 		}
     }
 }

--- a/js/commandController.js
+++ b/js/commandController.js
@@ -214,6 +214,11 @@ async function toggleServer(btn) {
         btn.html('<span class="con-ind connected"></span>Disconnect DCC++ EX');
     } else {
         selectMethod.disabled = false;
+		if (!"serial" in navigator) {
+			alert("No serial port found!\nYour browser may not be supported - check in the EX-WebThrottle documentation");
+		} else {
+			alert("Unable to connect");
+		}
     }
 }
 

--- a/js/exwebthrottle.js
+++ b/js/exwebthrottle.js
@@ -460,12 +460,7 @@ $(document).ready(function(){
 
   // Connect command station
   $("#button-connect").on("click", function () {
-	if ("serial" in navigator) {
-		toggleServer($(this));
-	} else {
-		//Browser not supported - pop up a window?
-		alert("No serial port found!\nYour browser may not be supported - check in the EX-WebThrottle documentation");
-	}
+    toggleServer($(this));
   });
 
   // Disconnect command station

--- a/js/exwebthrottle.js
+++ b/js/exwebthrottle.js
@@ -460,7 +460,12 @@ $(document).ready(function(){
 
   // Connect command station
   $("#button-connect").on("click", function () {
-    toggleServer($(this));
+	if ("serial" in navigator) {
+		toggleServer($(this));
+	} else {
+		//Browser not supported - pop up a window?
+		alert("No serial port found!\nYour browser may not be supported - check in the EX-WebThrottle documentation");
+	}
   });
 
   // Disconnect command station


### PR DESCRIPTION
This is a simple UX change to catch the low hanging fruit of "why doesn't this work? I hit the button and nothing happens!".

Before - Click the button, and this is what you see (no change)
![image](https://github.com/DCC-EX/WebThrottle-EX/assets/29041387/9373ad3a-47a7-4482-b16b-31057b266175)

After - Click the button, and an alert pops up!
![image](https://github.com/DCC-EX/WebThrottle-EX/assets/29041387/c38110aa-dfe0-47ff-bd6a-18cc18473e86)

So far, I have only tested this in Firefox and Edge. Edge will always offer you the option of COM1 on Windows, so it may be necessary to test this on another OS with a Chromium 89+ browser and no serial ports to confirm full coverage.

This impacts on some of the same areas as issue #42 - it's not a fix for operations in non-Chromium browsers, but it should at least let people know what's going on.