### PR TITLE
Show the string needed for the CS ROSTER entry

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# Version 1.3.40
+- Show the string needed for the CS ROSTER entry if added to a myConfiguration.h file, on the Functions Mapping page 
+
+# Version 1.3.39
+- Direction indication changes
+
 # Version 1.3.38
 - C_Carter's fix for the automations that require a loco
 

--- a/css/settings.css
+++ b/css/settings.css
@@ -107,7 +107,7 @@
 .maps-content{
     overflow-y: auto;
     font-size: 14px;
-    max-height: calc(100% - 90px);
+    max-height: calc(100% - 110px);
 }
 a.edit-cur-loco, a.option-btn{
     float: right;

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
  
         <link rel="manifest" href="manifest.json">
         <script>
-            var version = "1.3.39";
+            var version = "1.3.40";
         </script>
 
         <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon">

--- a/js/exwebthrottle.js
+++ b/js/exwebthrottle.js
@@ -308,6 +308,21 @@ function loadMapData(map, fromRoster) {
     );
   });
 
+  csRosterString = '<p><small>Roster Entry needed if added to your myConfiguration.h file:<br />ROSTER(loco_id,\"loco_name\",\"'
+  i=0;
+  $.each(data.fnData, function (key, value) {
+    if (value[3] == 1) {
+      csRosterString = csRosterString +
+        (value[1] == 1 ? "*" : "") +
+        value[2] +
+        (i<31 ? '/' : '')
+      ;
+    }
+    i++;
+  });
+  csRosterString = csRosterString + '\")' + '</small></p>';
+  container.append(csRosterString);
+
 }
 
 


### PR DESCRIPTION
- Show the string needed for the CS ROSTER entry if added to a myConfiguration.h file, on the Functions Mapping page