### PR TITLE
Add accessible keyboard and gamepad throttle controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ The circular control or vertical slider (chosen by the throttle select slider) c
 
 The options button lets you save labels to go on your function buttons for each of your locos. We will be updating this document soon to give you more information on this and other new features.
 
+## Physical controls
+
+When the throttle screen is active, keyboard and macropad controls are available without taking focus from a form field: Arrow Up/Down increase or decrease speed, F/B select forward or reverse, Space performs a normal stop, and Escape performs an emergency stop. A connected standard-mapping gamepad uses the left stick vertical axis for speed, A for normal stop, B for emergency stop, and D-pad left/right for reverse/forward. The on-screen button labels expose the keyboard shortcuts to assist screen-reader and sighted keyboard users.
+
 **Note:** The emulator doesn't fully replicate the Command station yet. This means that although the software works, not all the responses will be shown in
 the debug console. We are currently working on this, so it is something that will be fixed.
 

--- a/css/layout.css
+++ b/css/layout.css
@@ -273,3 +273,14 @@ hr{
     padding-left: 0;
     padding-right: 0;
 }
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}

--- a/index.html
+++ b/index.html
@@ -53,6 +53,7 @@
         <script  type="text/javascript" src="js/addloco.js"></script> 
         <script  type="text/javascript" src="js/emulator.js"></script>
         <script  type="text/javascript" src="js/exwebthrottle.js"></script>
+        <script  type="text/javascript" src="js/inputControls.js"></script>
         <script type="text/javascript" src="js/pwa.js"></script>
 
 <!--
@@ -181,7 +182,7 @@
                             <div class="row mobile-100  width100 flexx">
                                 <div class="column-7 flexx">
                                     <div class="flexx btns">
-                                        <button type="button" title="Decrease speed" class="btn-default btn btn btn-speed btn-left" name="button-left" access="false" id="button-left">
+                                        <button type="button" title="Decrease speed (Arrow Down)" aria-label="Decrease speed, keyboard shortcut Arrow Down" class="btn-default btn btn btn-speed btn-left" name="button-left" access="false" id="button-left">
                                             <span class="left" style="line-height: 12px;">&nbsp;-&nbsp;</span>
                                         </button>
                                     </div> 
@@ -202,7 +203,7 @@
                                             </div>
                                         </div>
                                         <div class="flexx btns">
-                                            <button type="button" title="Increase speed" class="btn-default btn btn-speed btn-right" name="button-right" access="false" id="button-right">
+                                            <button type="button" title="Increase speed (Arrow Up)" aria-label="Increase speed, keyboard shortcut Arrow Up" class="btn-default btn btn-speed btn-right" name="button-right" access="false" id="button-right">
                                                 <span class="right">&nbsp;+&nbsp;</span>
                                             </button> 
                                         </div>
@@ -210,17 +211,17 @@
                                     
                                     <div class=" column-2">
                                         <div class="em-btn">
-                                            <button class="em-stop" id="emergency-stop" title="Emergency Stop">
+                                            <button class="em-stop" id="emergency-stop" title="Emergency Stop (Escape)" aria-label="Emergency Stop, keyboard shortcut Escape">
                                                 <span class="icon-stop2"></span>
                                             </button>
                                         </div>
                                         <div class="dir-toggle">
-                                            <button class="dir-btn forward selected" id="dir-f" data-direction="forward" aria-label="forward" ><span class="arrow-up icon-up"></span></button>
+                                            <button class="dir-btn forward selected" id="dir-f" data-direction="forward" aria-label="Forward, keyboard shortcut F" ><span class="arrow-up icon-up"></span></button>
                                             <!-- <button class="dir-btn stop" id="dir-S" aria-label="stop"> <span class="stop"></span></button> -->
-                                            <button class="dir-btn backward" id="dir-b" data-direction="backward" aria-label="backward"> <span class="arrow-down icon-down"></button>        
+                                            <button class="dir-btn backward" id="dir-b" data-direction="backward" aria-label="Backward, keyboard shortcut B"> <span class="arrow-down icon-down"></button>
                                         </div>
                                         <div class="em-btn">
-                                            <button class="normal-stop" id="normal-stop" title="Stop">
+                                            <button class="normal-stop" id="normal-stop" title="Stop (Space)" aria-label="Stop, keyboard shortcut Space">
                                                 <span class="icon-stop2"></span>
                                             </button>
                                         </div>

--- a/js/inputControls.js
+++ b/js/inputControls.js
@@ -1,0 +1,102 @@
+/* Accessible keyboard, macropad, and gamepad controls for the throttle. */
+(function (window, document, $) {
+  "use strict";
+
+  var gamepadFrame = null;
+  var previousButtons = [];
+  var previousAxis = 0;
+  var gamepadActive = false;
+
+  function isTextEntry(target) {
+    if (!target || !target.tagName) return false;
+    return /^(INPUT|TEXTAREA|SELECT)$/.test(target.tagName) || target.isContentEditable;
+  }
+
+  function clickControl(selector) {
+    var control = document.querySelector(selector);
+    if (control && !control.disabled && !$(control).hasClass("ui-state-disabled")) {
+      control.click();
+      return true;
+    }
+    return false;
+  }
+
+  function announce(message) {
+    var live = document.getElementById("input-controls-status");
+    if (live) live.textContent = message;
+  }
+
+  function handleKey(event) {
+    if (isTextEntry(event.target) || event.altKey || event.ctrlKey || event.metaKey) return;
+
+    var selector;
+    switch (event.key) {
+      case "ArrowUp": selector = "#button-right"; break;
+      case "ArrowDown": selector = "#button-left"; break;
+      case "f": case "F": selector = "#dir-f"; break;
+      case "b": case "B": selector = "#dir-b"; break;
+      case " ": selector = "#normal-stop"; break;
+      case "Escape": selector = "#emergency-stop"; break;
+      default: return;
+    }
+
+    event.preventDefault();
+    if (clickControl(selector)) announce("Throttle control: " + selector.substring(1));
+  }
+
+  function buttonPressed(gamepad, index) {
+    return !!(gamepad.buttons[index] && gamepad.buttons[index].pressed);
+  }
+
+  function pollGamepad() {
+    var pads = navigator.getGamepads ? navigator.getGamepads() : [];
+    var pad = pads && pads[0];
+    if (!pad) {
+      gamepadFrame = null;
+      return;
+    }
+
+    var axis = pad.axes && pad.axes.length ? pad.axes[1] || 0 : 0;
+    if (axis < -0.5 && previousAxis >= -0.5) clickControl("#button-right");
+    if (axis > 0.5 && previousAxis <= 0.5) clickControl("#button-left");
+    previousAxis = axis;
+
+    // Standard mapping: A=normal stop, B=emergency stop, D-pad left/right=direction.
+    var actions = { 0: "#normal-stop", 1: "#emergency-stop", 14: "#dir-b", 15: "#dir-f" };
+    Object.keys(actions).forEach(function (index) {
+      var pressed = buttonPressed(pad, Number(index));
+      if (pressed && !previousButtons[index]) clickControl(actions[index]);
+      previousButtons[index] = pressed;
+    });
+    gamepadFrame = window.requestAnimationFrame(pollGamepad);
+  }
+
+  function connectGamepad() {
+    if (!gamepadActive) {
+      gamepadActive = true;
+      announce("Gamepad controls connected");
+      if (!gamepadFrame) gamepadFrame = window.requestAnimationFrame(pollGamepad);
+    }
+  }
+
+  function disconnectGamepad() {
+    gamepadActive = false;
+    previousButtons = [];
+    previousAxis = 0;
+    if (gamepadFrame) window.cancelAnimationFrame(gamepadFrame);
+    gamepadFrame = null;
+    announce("Gamepad controls disconnected");
+  }
+
+  $(function () {
+    $(document).on("keydown", handleKey);
+    window.addEventListener("gamepadconnected", connectGamepad);
+    window.addEventListener("gamepaddisconnected", disconnectGamepad);
+
+    var status = document.createElement("div");
+    status.id = "input-controls-status";
+    status.className = "sr-only";
+    status.setAttribute("aria-live", "polite");
+    document.body.appendChild(status);
+  });
+}(window, document, window.jQuery));

--- a/test/inputControls.test.js
+++ b/test/inputControls.test.js
@@ -1,0 +1,225 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+
+function createHarness() {
+  const elements = {};
+  const clicked = [];
+  const handlers = {};
+  let frame = null;
+  const gamepad = {
+    axes: [0, 0],
+    buttons: Array.from({ length: 16 }, () => ({ pressed: false })),
+  };
+
+  function createControl(selector, tagName = "BUTTON") {
+    const control = {
+      tagName,
+      disabled: false,
+      className: "",
+      click() {
+        clicked.push(selector);
+      },
+    };
+    elements[selector] = control;
+    return control;
+  }
+
+  createControl("#button-right");
+  createControl("#button-left");
+  createControl("#dir-f");
+  createControl("#dir-b");
+  createControl("#normal-stop");
+  createControl("#emergency-stop");
+  const textEntry = createControl("#loco-input", "INPUT");
+
+  const document = {
+    body: {
+      appendChild(element) {
+        elements[`#${element.id}`] = element;
+      },
+    },
+    createElement(tagName) {
+      return {
+        tagName: tagName.toUpperCase(),
+        id: "",
+        className: "",
+        textContent: "",
+        attributes: {},
+        setAttribute(name, value) {
+          this.attributes[name] = String(value);
+        },
+        getAttribute(name) {
+          return this.attributes[name] ?? null;
+        },
+      };
+    },
+    querySelector(selector) {
+      return elements[selector] || null;
+    },
+    getElementById(id) {
+      return elements[`#${id}`] || null;
+    },
+  };
+
+  function jquery(value) {
+    if (typeof value === "function") {
+      value();
+      return undefined;
+    }
+
+    return {
+      hasClass(name) {
+        return (value.className || "").split(/\s+/).includes(name);
+      },
+      on(eventName, callback) {
+        handlers[eventName] = callback;
+        return this;
+      },
+    };
+  }
+
+  const window = {
+    addEventListener(eventName, callback) {
+      handlers[eventName] = callback;
+    },
+    requestAnimationFrame(callback) {
+      frame = callback;
+      return 1;
+    },
+    cancelAnimationFrame() {
+      frame = null;
+    },
+    jQuery: jquery,
+  };
+
+  const navigator = {
+    getGamepads() {
+      return [gamepad];
+    },
+  };
+
+  const context = {
+    console: { log() {} },
+    document,
+    navigator,
+    window,
+    $: jquery,
+    jQuery: jquery,
+  };
+  vm.createContext(context);
+  const sourcePath = path.join(__dirname, "..", "js", "inputControls.js");
+  vm.runInContext(fs.readFileSync(sourcePath, "utf8"), context, {
+    filename: sourcePath,
+  });
+
+  return {
+    clicked,
+    handlers,
+    gamepad,
+    live: elements["#input-controls-status"],
+    buttonTarget: elements["#button-right"],
+    textEntry,
+    runFrame() {
+      assert.equal(typeof frame, "function");
+      frame();
+    },
+  };
+}
+
+function keyEvent(key, target) {
+  let prevented = 0;
+  return {
+    key,
+    target,
+    altKey: false,
+    ctrlKey: false,
+    metaKey: false,
+    preventDefault() {
+      prevented += 1;
+    },
+    get prevented() {
+      return prevented;
+    },
+  };
+}
+
+test("keyboard shortcuts click the mapped controls and announce the action", () => {
+  const harness = createHarness();
+  const target = harness.buttonTarget;
+  const handleKey = harness.handlers.keydown;
+
+  const up = keyEvent("ArrowUp", target);
+  handleKey(up);
+  const reverse = keyEvent("b", target);
+  handleKey(reverse);
+  const emergency = keyEvent("Escape", target);
+  handleKey(emergency);
+
+  assert.deepEqual(harness.clicked, ["#button-right", "#dir-b", "#emergency-stop"]);
+  assert.equal(up.prevented, 1);
+  assert.equal(reverse.prevented, 1);
+  assert.equal(emergency.prevented, 1);
+  assert.equal(harness.live.textContent, "Throttle control: emergency-stop");
+});
+
+test("keyboard shortcuts ignore text-entry and modified-key events", () => {
+  const harness = createHarness();
+  const handleKey = harness.handlers.keydown;
+
+  const textEntryEvent = keyEvent("ArrowUp", harness.textEntry);
+  handleKey(textEntryEvent);
+
+  const modifiedEvent = keyEvent("ArrowUp", harness.textEntry);
+  modifiedEvent.target = { tagName: "BUTTON" };
+  modifiedEvent.ctrlKey = true;
+  handleKey(modifiedEvent);
+
+  assert.deepEqual(harness.clicked, []);
+  assert.equal(textEntryEvent.prevented, 0);
+  assert.equal(modifiedEvent.prevented, 0);
+});
+
+test("gamepad axes and standard buttons map to throttle controls", () => {
+  const harness = createHarness();
+  harness.handlers.gamepadconnected();
+  assert.equal(harness.live.textContent, "Gamepad controls connected");
+  harness.runFrame();
+
+  harness.gamepad.axes[1] = -1;
+  harness.runFrame();
+  harness.gamepad.axes[1] = 0;
+  harness.runFrame();
+
+  harness.gamepad.buttons[0].pressed = true;
+  harness.runFrame();
+  harness.gamepad.buttons[0].pressed = false;
+  harness.runFrame();
+  harness.gamepad.buttons[1].pressed = true;
+  harness.runFrame();
+  harness.gamepad.buttons[1].pressed = false;
+  harness.runFrame();
+  harness.gamepad.buttons[14].pressed = true;
+  harness.runFrame();
+  harness.gamepad.buttons[14].pressed = false;
+  harness.runFrame();
+  harness.gamepad.buttons[15].pressed = true;
+  harness.runFrame();
+
+  assert.deepEqual(harness.clicked, [
+    "#button-right",
+    "#normal-stop",
+    "#emergency-stop",
+    "#dir-b",
+    "#dir-f",
+  ]);
+  harness.handlers.gamepaddisconnected();
+  assert.equal(harness.live.textContent, "Gamepad controls disconnected");
+});
+
+test("the status region is a polite live region", () => {
+  const harness = createHarness();
+  assert.equal(harness.live.getAttribute("aria-live"), "polite");
+});


### PR DESCRIPTION
## Summary

Adds accessible keyboard and standard-mapping gamepad controls for the WebThrottle-EX throttle, with dependency-free Node regression coverage.

## References and closing intent

- [#79 - EX-WebThrottle Gamepad Support](https://github.com/DCC-EX/WebThrottle-EX/issues/79)
- [#110 - Macropad and keyboard support for EX-WebThrottle](https://github.com/DCC-EX/WebThrottle-EX/issues/110)
- Prior fork-only PR: [BanjoR/WebThrottle-EX#1](https://github.com/BanjoR/WebThrottle-EX/pull/1), superseded and closed.

The standard-mapping gamepad implementation is complete within this PR scope:

- Fixes #79

The keyboard implementation addresses the throttle-action subset of #110. It intentionally does not add shortcuts for power, locomotive acquisition, or general UI navigation, so #110 remains a non-closing reference for maintainer follow-up.

## Bounded scope

The exact changed-file allowlist is README.md, css/layout.css, index.html, js/inputControls.js, and test/inputControls.test.js.

- Arrow Up/Down increase or decrease speed.
- F/B select forward or reverse.
- Space performs a normal stop.
- Escape performs an emergency stop.
- A standard gamepad uses the left-stick vertical axis for speed, A for normal stop, B for emergency stop, and D-pad left/right for reverse/forward.
- Shortcut handling ignores input, select, textarea, contenteditable, and modified-key events.
- On-screen labels expose the keyboard shortcuts and a polite live status region announces control/gamepad actions.
- The dependency-free Node test exercises keyboard mapping, text-entry safety, gamepad mapping, and live-region setup.

Excluded from this PR: firmware, protocol changes, locomotive/function semantics, hardware-specific drivers, vendor dependencies, build-system changes, and unrelated UI refactors.

## Validation

- PASS - Node regression suite: node --test - 4 passed.
- PASS - JavaScript syntax: node --check across all 14 project JavaScript and Node test files.
- PASS - Python/static validation: bundled Python html.parser parsed index.html and Python JSON parsing validated manifest.json.
- PASS - Diff/format hygiene: git diff --check passed; exactly the five allowlisted files differ from upstream master; no generated files are tracked.
- PASS - Accessibility surface: the speed button exposes the keyboard shortcut in its accessible name, and the dynamically created input-controls-status region has aria-live=polite.
- PASS - Browser smoke of the changed source: the emulator connected; locomotive 321 was acquired; Arrow Up produced <t 321 1 1>; Space produced <t 321 0 1>; B produced <t 321 0 0>; Escape produced <!>; the live status reported the emergency-stop action.
- PASS - Keyboard focus guard: pressing Arrow Up while the locomotive input was focused produced no throttle command.
- N/A - Current hosted CI: the BanjoR/WebThrottle-EX Actions API reports zero registered workflows for exact head 2cddd475846e55a93fda40bbb4c4977c40d5be60, so no current hosted result is claimed.
- HISTORICAL - The previous four-file head 9fbf7c29b44a1dd16b251f34e9a02f4fe77f7547 passed the available [Add Issue or Pull Request to Project run](https://github.com/DCC-EX/WebThrottle-EX/actions/runs/31948205696); that run predates the test-only commit and is not presented as current-head CI.
- PASS - PR metadata: [PR #153](https://github.com/DCC-EX/WebThrottle-EX/pull/153) is a BanjoR PR targeting DCC-EX master at head 2cddd47.
- PASS - Link audit: issue, prior-PR, current-PR, and historical Actions links resolve to the authoritative GitHub records.

## Validation limits

- N/A - Build/lint/Vitest: the repository has no package manifest, build command, lint configuration, or Vitest harness; the dependency-free Node suite above is the available automated test coverage.
- NOT RUN - Physical gamepad: no physical gamepad was available for local input-device validation. Maintainer bench criteria: connect a standard-mapping gamepad and verify left-stick speed, A normal stop, B emergency stop, D-pad direction, no action while typing, and live-region announcements.
- NOT RUN - Physical DCC hardware: no DCC hardware is available; the emulator smoke test is not a hardware claim.

This PR is ready for maintainer review; physical gamepad/runtime validation remains outstanding.

## Current exact-head CI status

N/A — No BanjoR fork Actions run exists for exact head `2cddd475846e55a93fda40bbb4c4977c40d5be60`; no hosted code-test result is claimed. Local validation above is the available evidence.
